### PR TITLE
Fix nested nonReentrant call

### DIFF
--- a/contracts/FlashLoanArbitrage.sol
+++ b/contracts/FlashLoanArbitrage.sol
@@ -298,7 +298,7 @@ contract FlashLoanArbitrage is ReentrancyGuard, Ownable {
         address _tokenA,
         uint256 _amount,
         address[] calldata _path
-    ) external nonReentrant {
+    ) external {
         require(_path.length >= 2, "Path must have at least two tokens");
 
         // Codificar os dados da arbitragem


### PR DESCRIPTION
## Summary
- remove `nonReentrant` modifier from `initiateArbitrageFromBackend`

## Testing
- `npx hardhat test test/FlashLoanArbitrage.test.js` *(fails: E403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_685645271b048325b9c819caea689dd4