### PR TITLE
Fix dynamic arbitrage method call

### DIFF
--- a/src/services/triangularArbitrageService.js
+++ b/src/services/triangularArbitrageService.js
@@ -625,7 +625,7 @@ class TriangularArbitrageService {
 
     // 4. Executar no contrato
     try {
-      const tx = await blockchainService.initiateDynamicArbitrage(
+      const tx = await this.blockchainService.initiateDynamicArbitrage(
         tokenAddresses[0], // Token do flash loan
         flashLoanAmount,
         minReturn,


### PR DESCRIPTION
## Summary
- call `initiateDynamicArbitrage` on the existing service instance
- implement `BlockchainService.initiateDynamicArbitrage`

## Testing
- `npm test` *(fails: Cannot find module '@apollo/client/core')*

------
https://chatgpt.com/codex/tasks/task_b_68586491371c8325bf0f5b220d13b8f7