### PR TITLE
Initialize BlockchainService earlier

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -8,8 +8,12 @@ Servidor Express.js que serve como API backend para o frontend React, integrando
 - **ArbitrageService**: Detecção de arbitragem direta com AlertEngine e CacheManager
 - **GraphService**: Busca dados reais das DEXs via subgraphs
 - **TriangularArbitrageService**: Detecção de oportunidades triangulares
-- **BlockchainService**: Interação com blockchain e estimativa de gás
+- **BlockchainService**: Interação com blockchain, inicialização do contrato de flash loan e estimativa de gás
 - **CacheManager**: Cache inteligente para otimização de performance
+
+Durante a inicialização (`initializeServices`), o `BlockchainService` é criado
+antes dos serviços de arbitragem e seu contrato de flash loan é configurado de
+forma síncrona para garantir disponibilidade imediata.
 
 ### 🌐 API REST Endpoints
 

--- a/server/index.js
+++ b/server/index.js
@@ -49,9 +49,13 @@ class DefiArbitrageServer {
     try {
       this.cacheManager = new CacheManager();
       this.graphService = new GraphService();
-      this.arbitrageService = new ArbitrageService(this.cacheManager);
-      this.triangularArbitrageService = new TriangularArbitrageService();
+
+      // BlockchainService deve ser inicializado antes dos demais
       this.blockchainService = new BlockchainService();
+      this.blockchainService.initializeFlashLoanContract();
+
+      this.arbitrageService = new ArbitrageService(this.blockchainService);
+      this.triangularArbitrageService = new TriangularArbitrageService(this.blockchainService);
       
       console.log('✅ Todos os serviços inicializados com sucesso');
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure BlockchainService is created before other services
- initialise flash loan contract on service creation
- pass the blockchainService instance to ArbitrageService and TriangularArbitrageService
- document the new initialisation behaviour

## Testing
- `npm run test` *(fails: Cannot find module '@apollo/client/core')*

------
https://chatgpt.com/codex/tasks/task_b_685863c74b408325bc298c7e58502c5d