### PR TITLE
Add single asset flash loan execution

### DIFF
--- a/env.example
+++ b/env.example
@@ -16,7 +16,7 @@ UPDATE_INTERVAL=15000
 CHECK_INTERVAL=5000
 
 # Endereços dos contratos (após deploy)
-FLASH_LOAN_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
+FLASH_LOAN_CONTRACT_ADDRESS=0x1111111111111111111111111111111111111111
 
 # Tokens monitorados (endereços reais encontrados nos subgraphs)
 # Tokens principais (com liquidez)


### PR DESCRIPTION
## Summary
- extend `FlashLoanArbitrage` with single-asset `executeOperation`
- update example environment with placeholder contract address

## Testing
- `npx hardhat compile` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_6859fc6eb3e483259e7603744c52ec86