### PR TITLE
Fix flash loan receiver

### DIFF
--- a/src/services/blockchainService.js
+++ b/src/services/blockchainService.js
@@ -163,7 +163,7 @@ class BlockchainService {
       console.log(`🚀 Executando flash loan: ${ethers.utils.formatEther(amount)} ${asset}`);
       
       const tx = await this.flashLoanContract.flashLoanSimple(
-        this.wallet.address, // receiver
+        this.flashLoanContract.address, // contract address acts as receiver
         asset, // asset address
         amount, // amount
         data, // data


### PR DESCRIPTION
## Summary
- call `flashLoanSimple` with the flash loan contract's own address so the contract is the receiver

## Testing
- `npm test` *(fails: Cannot find module '@apollo/client/core')*

------
https://chatgpt.com/codex/tasks/task_b_6859fe3bd2148325816f004c1974864a